### PR TITLE
If XML element is empty and type STRUCT or ARRAY, skip.

### DIFF
--- a/XmlRpcCs/XmlRpcDeserializer.cs
+++ b/XmlRpcCs/XmlRpcDeserializer.cs
@@ -71,10 +71,12 @@ namespace Nwc.XmlRpc
                             _text = null;
                             break;
                         case STRUCT:
+                            if (reader.IsEmptyElement) break;
                             PushContext();
                             _container = new Hashtable();
                             break;
                         case ARRAY:
+                            if (reader.IsEmptyElement) break;
                             PushContext();
                             _container = new ArrayList();
                             break;


### PR DESCRIPTION
When receiving an XML-RPC response from an external server, elements may occasionally be empty. This may cause context synchronization issues during deserialization, since an empty element does not generate an `EndElement` node, see e.g. [this](https://stackoverflow.com/q/241336) StackOverflow question and answer.

In particular, this becomes an issue for empty `<struct/>` and `<array/>` elements, where a new container is pushed to the context stack but can never be popped since the corresponding `EndElement` node is never generated.

To overcome this issue, I have added checks in the `XmlRpcDeserializer.DeserializeNode` method, where no container is pushed or a new one created when the current `Element` node is empty and the element is named `STRUCT` or `ARRAY`.

Hopefully these additions are sufficient for handling any occurring empty elements.